### PR TITLE
EOSIO Signing Requests (ESR) – Revision 2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+arrowParens: "always"
+bracketSpacing: false
+endOfLine: "lf"
+printWidth: 100
+semi: false
+singleQuote: true
+tabWidth: 4
+trailingComma: "es5"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lib/*"
   ],
   "dependencies": {
-    "eosjs": "^20.0.0"
+    "eosjs": "^20.0.0",
+    "fast-sha256": "^1.1.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eosio-uri",
+  "name": "eosio-signing-request",
   "version": "0.0.5",
   "description": "`eosio:` uri encoder and decoder",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.8",
     "mocha": "^6.1.4",
+    "prettier": "^1.19.1",
     "ts-node": "^8.2.0",
     "tslint": "^5.12.0",
+    "tslint-config-prettier": "^1.18.0",
+    "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/index",
   "typings": "./lib/index",
   "scripts": {
-    "prepack": "make lib"
+    "prepare": "make lib"
   },
   "files": [
     "lib/*"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/index",
   "typings": "./lib/index",
   "scripts": {
-    "prepublish": "make lib"
+    "prepack": "make lib"
   },
   "files": [
     "lib/*"

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -6,7 +6,8 @@ export type PermissionName = string /*name*/
 export type ChainAlias = number /*uint8*/
 export type ChainId = string /*checksum256*/
 export type VariantId = ['chain_alias', ChainAlias] | ['chain_id', ChainId]
-export type VariantReq = ['action', Action] | ['action[]', Action[]] | ['transaction', Transaction]
+export type VariantReq = ['action', Action] | ['action[]', Action[]] |
+    ['transaction', Transaction] | ['identity', Identity]
 
 export interface PermissionLevel {
     actor: AccountName
@@ -49,7 +50,18 @@ export interface SigningRequest {
     chain_id: VariantId
     req: VariantReq
     broadcast: boolean
-    callback: Callback | undefined
+    callback: Callback | undefined | null
+}
+
+export interface Identity {
+    account: AccountName
+    sender: AccountName
+    request_key: string | undefined | null /*public_key*/
+}
+
+export interface RequestSignature {
+    signer: AccountName
+    signature: string
 }
 
 export const data = {
@@ -205,6 +217,36 @@ export const data = {
                 },
             ],
         },
+        {
+            name: 'identity',
+            fields: [
+                {
+                    name: 'account',
+                    type: 'name',
+                },
+                {
+                    name: 'sender',
+                    type: 'name',
+                },
+                {
+                    name: 'request_key',
+                    type: 'public_key?',
+                },
+            ],
+        },
+        {
+            name: 'request_signature',
+            fields: [
+                {
+                    name: 'signer',
+                    type: 'name',
+                },
+                {
+                    name: 'signature',
+                    type: 'signature',
+                },
+            ],
+        },
     ],
     variants: [
         {
@@ -213,7 +255,7 @@ export const data = {
         },
         {
             name: 'variant_req',
-            types: ['action', 'action[]', 'transaction'],
+            types: ['action', 'action[]', 'transaction', 'identity'],
         },
     ],
 }

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -55,7 +55,6 @@ export interface SigningRequest {
 
 export interface Identity {
     account: AccountName
-    sender: AccountName
     request_key: string | undefined | null /*public_key*/
 }
 
@@ -225,10 +224,6 @@ export const data = {
                     type: 'name',
                 },
                 {
-                    name: 'sender',
-                    type: 'name',
-                },
-                {
                     name: 'request_key',
                     type: 'public_key?',
                 },
@@ -256,6 +251,12 @@ export const data = {
         {
             name: 'variant_req',
             types: ['action', 'action[]', 'transaction', 'identity'],
+        },
+    ],
+    actions: [
+        {
+            name: 'identity',
+            type: 'identity',
         },
     ],
 }

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -6,8 +6,11 @@ export type PermissionName = string /*name*/
 export type ChainAlias = number /*uint8*/
 export type ChainId = string /*checksum256*/
 export type VariantId = ['chain_alias', ChainAlias] | ['chain_id', ChainId]
-export type VariantReq = ['action', Action] | ['action[]', Action[]] |
-    ['transaction', Transaction] | ['identity', Identity]
+export type VariantReq =
+    | ['action', Action]
+    | ['action[]', Action[]]
+    | ['transaction', Transaction]
+    | ['identity', Identity]
 
 export interface PermissionLevel {
     actor: AccountName
@@ -18,7 +21,7 @@ export interface Action {
     account: AccountName
     name: ActionName
     authorization: PermissionLevel[]
-    data: string | { [key: string]: any }
+    data: string | {[key: string]: any}
 }
 
 export interface Extension {

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -17,6 +17,11 @@ export interface PermissionLevel {
     permission: PermissionName
 }
 
+export type RequestFlags = number
+export const RequestFlagsNone = 0
+export const RequestFlagsBroadcast = 1 << 0
+export const RequestFlagsBackground = 1 << 1
+
 export interface Action {
     account: AccountName
     name: ActionName
@@ -44,16 +49,11 @@ export interface Transaction extends TransactionHeader {
     transaction_extensions: Extension[]
 }
 
-export interface Callback {
-    url: string /*string*/
-    background: boolean
-}
-
 export interface SigningRequest {
     chain_id: VariantId
     req: VariantReq
-    broadcast: boolean
-    callback: Callback | undefined | null
+    flags: RequestFlags
+    callback: string
 }
 
 export interface Identity {
@@ -88,6 +88,10 @@ export const data = {
         {
             new_type_name: 'chain_id',
             type: 'checksum256',
+        },
+        {
+            new_type_name: 'request_flags',
+            type: 'uint8',
         },
     ],
     structs: [
@@ -186,15 +190,15 @@ export const data = {
             ],
         },
         {
-            name: 'callback',
+            name: 'info_pair',
             fields: [
                 {
-                    name: 'url',
+                    name: 'key',
                     type: 'string',
                 },
                 {
-                    name: 'background',
-                    type: 'bool',
+                    name: 'value',
+                    type: 'string',
                 },
             ],
         },
@@ -210,12 +214,16 @@ export const data = {
                     type: 'variant_req',
                 },
                 {
-                    name: 'broadcast',
-                    type: 'bool',
+                    name: 'flags',
+                    type: 'request_flags',
                 },
                 {
                     name: 'callback',
-                    type: 'callback?',
+                    type: 'string',
+                },
+                {
+                    name: 'info',
+                    type: 'info_pair[]',
                 },
             ],
         },

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -63,8 +63,7 @@ export interface InfoPair {
 }
 
 export interface Identity {
-    account: AccountName
-    request_key: string | undefined | null /*public_key*/
+    permission: PermissionLevel | undefined | null
 }
 
 export interface RequestSignature {
@@ -237,12 +236,8 @@ export const data = {
             name: 'identity',
             fields: [
                 {
-                    name: 'account',
-                    type: 'name',
-                },
-                {
-                    name: 'request_key',
-                    type: 'public_key?',
+                    name: 'permission',
+                    type: 'permission_level?',
                 },
             ],
         },

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -54,6 +54,12 @@ export interface SigningRequest {
     req: VariantReq
     flags: RequestFlags
     callback: string
+    info: InfoPair[]
+}
+
+export interface InfoPair {
+    key: string
+    value: Uint8Array | string /*bytes*/
 }
 
 export interface Identity {
@@ -198,7 +204,7 @@ export const data = {
                 },
                 {
                     name: 'value',
-                    type: 'string',
+                    type: 'bytes',
                 },
             ],
         },

--- a/src/base64u.ts
+++ b/src/base64u.ts
@@ -29,9 +29,9 @@ export function encode(data: Uint8Array): string {
 
         // Use bitmasks to extract 6-bit segments from the triplet
         a = (chunk & 16515072) >> 18 // 16515072 = (2^6 - 1) << 18
-        b = (chunk & 258048) >> 12   // 258048   = (2^6 - 1) << 12
-        c = (chunk & 4032) >> 6      // 4032     = (2^6 - 1) << 6
-        d = chunk & 63               // 63       =  2^6 - 1
+        b = (chunk & 258048) >> 12 // 258048   = (2^6 - 1) << 12
+        c = (chunk & 4032) >> 6 // 4032     = (2^6 - 1) << 6
+        d = chunk & 63 // 63       =  2^6 - 1
 
         // Convert the raw binary segments to the appropriate ASCII encoding
         parts.push(charset[a] + charset[b] + charset[c] + charset[d])
@@ -51,7 +51,7 @@ export function encode(data: Uint8Array): string {
         chunk = (data[mainLength] << 8) | data[mainLength + 1]
 
         a = (chunk & 64512) >> 10 // 64512 = (2^6 - 1) << 10
-        b = (chunk & 1008) >> 4   // 1008  = (2^6 - 1) << 4
+        b = (chunk & 1008) >> 4 // 1008  = (2^6 - 1) << 4
 
         // Set the 2 least significant bits to zero
         c = (chunk & 15) << 2 // 15    = 2^4 - 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './signing-request'
 import * as abi from './abi'
-export { abi }
+export {abi}

--- a/src/signing-request.ts
+++ b/src/signing-request.ts
@@ -330,6 +330,9 @@ export class SigningRequest {
 
     /** Creates a signing request from encoded `eosio:` uri string. */
     public static from(uri: string, options: SigningRequestEncodingOptions = {}) {
+        if (typeof uri !== 'string') {
+            throw new Error('Invalid request uri')
+        }
         const [scheme, path] = uri.split(':')
         if (scheme !== 'eosio' && scheme !== 'web+eosio') {
             throw new Error('Invalid scheme')

--- a/src/signing-request.ts
+++ b/src/signing-request.ts
@@ -864,21 +864,6 @@ async function serializeAction(
     )
 }
 
-function parseSigner(signer: string | abi.PermissionLevel): abi.PermissionLevel {
-    if (typeof signer === 'string') {
-        const [actor, permission] = signer.split('@')
-        signer = {actor, permission}
-    }
-    if (
-        typeof signer !== 'object' ||
-        typeof signer.actor !== 'string' ||
-        typeof signer.permission !== 'string'
-    ) {
-        throw new TypeError('Invalid signer')
-    }
-    return signer
-}
-
 function callbackValue(callback?: CallbackType): abi.Callback | null {
     if (typeof callback === 'string') {
         return {background: false, url: callback}

--- a/src/signing-request.ts
+++ b/src/signing-request.ts
@@ -354,6 +354,12 @@ export class SigningRequest {
         abiProvider?: AbiProvider,
         signature?: abi.RequestSignature,
     ) {
+        if (data.broadcast === true && data.req[0] === 'identity') {
+            throw new Error('Invalid request (identity request cannot be broadcast)')
+        }
+        if (data.broadcast === false && data.broadcast == null) {
+            throw new Error('Invalid request (nothing to do, no broadcast or callback set)')
+        }
         this.version = version
         this.data = data
         this.textEncoder = textEncoder

--- a/src/signing-request.ts
+++ b/src/signing-request.ts
@@ -572,8 +572,11 @@ export class SigningRequest {
         array.set(data, 0)
         array.set(sigData, data.byteLength)
         if (shouldCompress) {
-            header |= 1 << 7
-            array = this.zlib!.deflateRaw(array)
+            const deflated = this.zlib!.deflateRaw(array)
+            if (array.byteLength > deflated.byteLength) {
+                header |= 1 << 7
+                array = deflated
+            }
         }
         const out = new Uint8Array(1 + array.byteLength)
         out[0] = header

--- a/test/request.ts
+++ b/test/request.ts
@@ -405,4 +405,20 @@ describe('signing request', function() {
         )
         assert.strictEqual(req3.encode(), req3uri)
     })
+
+    it('should encode and decode with metadata', async function() {
+        let req = await SigningRequest.identity(
+            {
+                callback: 'https://example.com',
+                info: {
+                    foo: 'bar',
+                    baz: new Uint8Array([0x00, 0x01, 0x02]) as any,
+                },
+            },
+            options
+        )
+        let decoded = SigningRequest.from(req.encode(), options)
+        assert.deepStrictEqual(decoded.getInfo(), req.getInfo())
+        assert.deepStrictEqual(decoded.getInfo(), {foo: 'bar', baz: '\u0000\u0001\u0002'})
+    })
 })

--- a/test/request.ts
+++ b/test/request.ts
@@ -1,7 +1,13 @@
 import * as assert from 'assert'
 import 'mocha'
 import {TextDecoder, TextEncoder} from 'util'
-import {SignatureProvider, SigningRequest, SigningRequestEncodingOptions} from '../src'
+import {
+    PlaceholderAuth,
+    PlaceholderName,
+    SignatureProvider,
+    SigningRequest,
+    SigningRequestEncodingOptions,
+} from '../src'
 import abiProvider from './utils/mock-abi-provider'
 import mockAbiProvider from './utils/mock-abi-provider'
 import zlib from './utils/node-zlib-provider'
@@ -40,14 +46,19 @@ describe('signing request', function() {
                         '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
                 },
             ],
-            callback: null,
-            broadcast: true,
+            callback: '',
+            flags: 1,
+            info: [],
         })
     })
 
     it('should create from actions', async function() {
         const request = await SigningRequest.create(
             {
+                callback: {
+                    url: 'https://example.com/?tx={{tx}}',
+                    background: true,
+                },
                 actions: [
                     {
                         account: 'eosio.token',
@@ -86,14 +97,17 @@ describe('signing request', function() {
                     },
                 ],
             ],
-            callback: null,
-            broadcast: true,
+            callback: 'https://example.com/?tx={{tx}}',
+            flags: 3,
+            info: [],
         })
     })
 
     it('should create from transaction', async function() {
         const request = await SigningRequest.create(
             {
+                broadcast: false,
+                callback: 'https://example.com/?tx={{tx}}',
                 transaction: {
                     delay_sec: 123,
                     expiration: timestamp,
@@ -135,8 +149,32 @@ describe('signing request', function() {
                     transaction_extensions: [],
                 },
             ],
-            callback: null,
-            broadcast: true,
+            callback: 'https://example.com/?tx={{tx}}',
+            flags: 0,
+            info: [],
+        })
+    })
+
+    it('should create from uri', async function() {
+        const request = await SigningRequest.from(
+            'esr://gmNgZGBY1mTC_MoglIGBIVzX5uxZRqAQGMBoExgDAjRi4fwAVz93ICUckpGYl12skJZfpFCSkaqQllmcwczAAAA',
+            options
+        )
+        assert.deepStrictEqual(request.data, {
+            chain_id: ['chain_alias', 1],
+            req: [
+                'action',
+                {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [PlaceholderAuth],
+                    data:
+                        '0100000000000000000000000000285D01000000000000000050454E47000000135468616E6B7320666F72207468652066697368',
+                },
+            ],
+            callback: '',
+            flags: 3,
+            info: [],
         })
     })
 
@@ -234,11 +272,20 @@ describe('signing request', function() {
     it('should encode and decode requests', async function() {
         const req1 = await SigningRequest.create(
             {
+                callback: {
+                    url: '',
+                    background: true,
+                },
                 action: {
                     account: 'eosio.token',
                     name: 'transfer',
-                    authorization: [{actor: 'foo', permission: 'active'}],
-                    data: {from: 'foo', to: 'bar', quantity: '1.0000 EOS', memo: 'hello there'},
+                    authorization: [PlaceholderAuth],
+                    data: {
+                        from: PlaceholderName,
+                        to: 'foo',
+                        quantity: '1. PENG',
+                        memo: 'Thanks for the fish',
+                    },
                 },
             },
             options
@@ -246,7 +293,7 @@ describe('signing request', function() {
         const encoded = req1.encode()
         assert.strictEqual(
             encoded,
-            'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZCqhDWCyu_sEgmjsjNScnX6EkI7UolZEBAA'
+            'esr://gmNgZGBY1mTC_MoglIGBIVzX5uxZRqAQGMBoExgDAjRi4fwAVz93ICUckpGYl12skJZfpFCSkaqQllmcwczAAAA'
         )
         const req2 = SigningRequest.from(encoded, options)
         assert.deepStrictEqual(req2.data, req1.data)
@@ -321,7 +368,7 @@ describe('signing request', function() {
         let encoded = req1.encode()
         assert.strictEqual(
             encoded,
-            'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKlQ3SLV8anjWFNWd23XWfvzTcy_qmtRx5mtMXlkSC23ZXle6K_NJFJ4SVTb4O026Wb1G5Wx0u1A3-_G4rAPsBp78z9lN7nddAQA'
+            'esr://gmNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKlQ3WLl8anjWFNWd23XWfvzTcy_qmtRx5mtMXlkSC23ZXle6K_NJFJ4SVTb4O026Wb1G5Wx0u1A3-_G4rAPsBp78z9lN7nddAQA'
         )
         let req2 = SigningRequest.from(encoded, options)
         assert.deepStrictEqual(req2.data, req1.data)
@@ -330,9 +377,9 @@ describe('signing request', function() {
 
     it('should encode and decode test requests', async function() {
         let req1uri =
-            'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKiMDAA'
+            'esr://gmNgZGBY1mTC_MoglIGBIVzX5uxZRqAQGMBoExgDAjRi4fwAVz93ICUckpGYl12skJZfpFCSkaqQllmcwczAAAA'
         let req2uri =
-            'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKkR3TDFQtYKjRZLW-rkn5z86tuzPxn7zSXZ7lkyOdFE_-tTE8_bqS4ab6vnUd_LqHG3ZVHCmNnW9qt6zEx9amy_k_FC6nqX1Uf7TdgA'
+            'esr://gmNgZGBY1mTC_MoglIGBIVzX5uxZRqAQGMBoExgDAjRi4fwAVz93ICUckpGYl12skJZfpFCSkaqQllmcwQxREVOsEcsgX-9-jqsy1EhNQM_GM_FkQMIziUU1VU4PsmOn_3r5hUMumeN3PXvdSuWMm1o9u6-FmCwtPvR0haqt12fNKtlWzTuiNwA'
         let req1 = SigningRequest.from(req1uri, options)
         let req2 = SigningRequest.from(req2uri, options)
         assert.deepStrictEqual(
@@ -343,12 +390,12 @@ describe('signing request', function() {
         assert.deepStrictEqual(req2.signature, {
             signer: 'foobar',
             signature:
-                'SIG_K1_KdHDFseJF6paedvSbfHFZzhbtBDVAM8LxeDJsrG33sENRbUQMFHX8CvtT9wRLo4fE4QGYtbp1rF6BqNQ6Pv5XgSocXwM67',
+                'SIG_K1_KBub1qmdiPpWA2XKKEZEG3EfKJBf38GETHzbd4t3CBdWLgdvFRLCqbcUsBbbYga6jmxfdSFfodMdhMYraKLhEzjSCsiuMs',
         })
         assert.strictEqual(req1.encode(), req1uri)
         assert.strictEqual(req2.encode(), req2uri)
         let req3uri =
-            'eosio:gWNgZGZkgABGBqYI7x9Sxl36f-rbJt9s2lUzbYe3pdtE7WnPfxy7_pAph3k5A6NKTmZetpW-fnKGXmJeckZ-kR5IQN_QyNhE18TUzFzXwtLAgBEA'
+            'esr://gmNgZGZkgABGBqYI7x9Sxl36f-rbJt9s2lUzbYe3pdtE7WnPfxy7_pAph3k5k2pGSUlBsZW-fnKGXmJeckZ-kV5OZl62vqGRsYmuiamZua6FpYEBAwA'
         let req3 = SigningRequest.from(req3uri, options)
         assert.strictEqual(req3.isIdentity(), true)
         assert.strictEqual(req3.getIdentity(), null)

--- a/test/request.ts
+++ b/test/request.ts
@@ -244,6 +244,7 @@ describe('signing request', function() {
     it('should create identity tx', async function() {
         let req = await SigningRequest.identity(
             {
+                request_key: 'EOS6TXNeWW12K2owiRE67rxHKonBjdLyLPgq8C12fg6EVMrFFreQs',
                 callback: {
                     background: true,
                     url: 'https://example.com',
@@ -258,7 +259,10 @@ describe('signing request', function() {
                     account: '',
                     name: 'identity',
                     authorization: [],
-                    data: '000000000000285D00',
+                    data: {
+                        account: 'foo',
+                        request_key: 'PUB_K1_6TXNeWW12K2owiRE67rxHKonBjdLyLPgq8C12fg6EVMrEriLR9',
+                    },
                 },
             ],
             context_free_actions: [],

--- a/test/request.ts
+++ b/test/request.ts
@@ -1,12 +1,13 @@
 import * as assert from 'assert'
 import 'mocha'
 import {TextDecoder, TextEncoder} from 'util'
-import {SigningRequest, SigningRequestEncodingOptions, SignatureProvider} from '../src'
+import {SignatureProvider, SigningRequest, SigningRequestEncodingOptions} from '../src'
 import abiProvider from './utils/mock-abi-provider'
 import zlib from './utils/node-zlib-provider'
 
 const options: SigningRequestEncodingOptions = {
-    abiProvider, zlib,
+    abiProvider,
+    zlib,
     textDecoder: new TextDecoder(),
     textEncoder: new TextEncoder(),
 }
@@ -14,107 +15,142 @@ const options: SigningRequestEncodingOptions = {
 const timestamp = '2018-02-15T00:00:00.000'
 
 describe('signing request', function() {
-
     it('should create from action', async function() {
-        const request = await SigningRequest.create({
-            action: {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+        const request = await SigningRequest.create(
+            {
+                action: {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: 'foo', permission: 'active'}],
+                    data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+                },
             },
-        }, options)
+            options
+        )
         assert.deepStrictEqual(request.data, {
             chain_id: ['chain_alias', 1],
-            req: ['action', {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
-            }],
+            req: [
+                'action',
+                {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: 'foo', permission: 'active'}],
+                    data:
+                        '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
+                },
+            ],
             callback: null,
             broadcast: true,
         })
     })
 
     it('should create from actions', async function() {
-        const request = await SigningRequest.create({
-            actions: [{
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
-            }, {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'baz', permission: 'active'}],
-                data: {from: 'baz', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
-            }],
-        }, options)
+        const request = await SigningRequest.create(
+            {
+                actions: [
+                    {
+                        account: 'eosio.token',
+                        name: 'transfer',
+                        authorization: [{actor: 'foo', permission: 'active'}],
+                        data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+                    },
+                    {
+                        account: 'eosio.token',
+                        name: 'transfer',
+                        authorization: [{actor: 'baz', permission: 'active'}],
+                        data: {from: 'baz', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+                    },
+                ],
+            },
+            options
+        )
         assert.deepStrictEqual(request.data, {
             chain_id: ['chain_alias', 1],
-            req: ['action[]', [{
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
-            }, {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'baz', permission: 'active'}],
-                data: '000000000000BE39000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
-            }]],
+            req: [
+                'action[]',
+                [
+                    {
+                        account: 'eosio.token',
+                        name: 'transfer',
+                        authorization: [{actor: 'foo', permission: 'active'}],
+                        data:
+                            '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
+                    },
+                    {
+                        account: 'eosio.token',
+                        name: 'transfer',
+                        authorization: [{actor: 'baz', permission: 'active'}],
+                        data:
+                            '000000000000BE39000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
+                    },
+                ],
+            ],
             callback: null,
             broadcast: true,
         })
     })
 
     it('should create from transaction', async function() {
-        const request = await SigningRequest.create({
-            transaction: {
-                delay_sec: 123,
-                expiration: timestamp,
-                max_cpu_usage_ms: 99,
-                actions: [{
-                    account: 'eosio.token',
-                    name: 'transfer',
-                    authorization: [{actor: 'foo', permission: 'active'}],
-                    data: '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
-                }],
+        const request = await SigningRequest.create(
+            {
+                transaction: {
+                    delay_sec: 123,
+                    expiration: timestamp,
+                    max_cpu_usage_ms: 99,
+                    actions: [
+                        {
+                            account: 'eosio.token',
+                            name: 'transfer',
+                            authorization: [{actor: 'foo', permission: 'active'}],
+                            data:
+                                '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
+                        },
+                    ],
+                },
             },
-        }, options)
+            options
+        )
         assert.deepStrictEqual(request.data, {
             chain_id: ['chain_alias', 1],
-            req: ['transaction', {
-                actions: [{
-                    account: 'eosio.token',
-                    name: 'transfer',
-                    authorization: [{actor: 'foo', permission: 'active'}],
-                    data: '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
-                }],
-                context_free_actions: [],
-                delay_sec: 123,
-                expiration: timestamp,
-                max_cpu_usage_ms: 99,
-                max_net_usage_words: 0,
-                ref_block_num: 0,
-                ref_block_prefix: 0,
-                transaction_extensions: [],
-            }],
+            req: [
+                'transaction',
+                {
+                    actions: [
+                        {
+                            account: 'eosio.token',
+                            name: 'transfer',
+                            authorization: [{actor: 'foo', permission: 'active'}],
+                            data:
+                                '000000000000285D000000000000AE39E80300000000000003454F53000000000B68656C6C6F207468657265',
+                        },
+                    ],
+                    context_free_actions: [],
+                    delay_sec: 123,
+                    expiration: timestamp,
+                    max_cpu_usage_ms: 99,
+                    max_net_usage_words: 0,
+                    ref_block_num: 0,
+                    ref_block_prefix: 0,
+                    transaction_extensions: [],
+                },
+            ],
             callback: null,
             broadcast: true,
         })
     })
 
     it('should resolve to transaction', async function() {
-        const request = await SigningRequest.create({
-            action: {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+        const request = await SigningRequest.create(
+            {
+                action: {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: 'foo', permission: 'active'}],
+                    data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+                },
             },
-        }, options)
+            options
+        )
         const tx = await request.getTransaction('foo@active', {
             timestamp,
             block_num: 1234,
@@ -123,12 +159,12 @@ describe('signing request', function() {
         })
         assert.deepStrictEqual(tx, {
             actions: [
-              {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
-              },
+                {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: 'foo', permission: 'active'}],
+                    data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+                },
             ],
             context_free_actions: [],
             transaction_extensions: [],
@@ -142,14 +178,22 @@ describe('signing request', function() {
     })
 
     it('should resolve with placeholder name', async function() {
-        const request = await SigningRequest.create({
-            action: {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: '............1', permission: '............1'}],
-                data: {from: '............1', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+        const request = await SigningRequest.create(
+            {
+                action: {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: '............1', permission: '............1'}],
+                    data: {
+                        from: '............1',
+                        to: 'bar',
+                        quantity: '1.000 EOS',
+                        memo: 'hello there',
+                    },
+                },
             },
-        }, options)
+            options
+        )
         const tx = await request.getTransaction('foo@active', {
             timestamp,
             block_num: 1234,
@@ -158,12 +202,12 @@ describe('signing request', function() {
         })
         assert.deepStrictEqual(tx, {
             actions: [
-              {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
-              },
+                {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: 'foo', permission: 'active'}],
+                    data: {from: 'foo', to: 'bar', quantity: '1.000 EOS', memo: 'hello there'},
+                },
             ],
             context_free_actions: [],
             transaction_extensions: [],
@@ -177,14 +221,17 @@ describe('signing request', function() {
     })
 
     it('should encode and decode requests', async function() {
-        const req1 = await SigningRequest.create({
-            action: {
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{actor: 'foo', permission: 'active'}],
-                data: {from: 'foo', to: 'bar', quantity: '1.0000 EOS', memo: 'hello there'},
+        const req1 = await SigningRequest.create(
+            {
+                action: {
+                    account: 'eosio.token',
+                    name: 'transfer',
+                    authorization: [{actor: 'foo', permission: 'active'}],
+                    data: {from: 'foo', to: 'bar', quantity: '1.0000 EOS', memo: 'hello there'},
+                },
             },
-        }, options)
+            options
+        )
         const encoded = req1.encode()
         assert.strictEqual(
             encoded,
@@ -192,14 +239,18 @@ describe('signing request', function() {
         )
         const req2 = SigningRequest.from(encoded, options)
         assert.deepStrictEqual(req2.data, req1.data)
-
     })
 
     it('should create identity tx', async function() {
-        let req = await SigningRequest.identity({callback: {
-            background: true,
-            url: 'https://example.com'
-        }}, options)
+        let req = await SigningRequest.identity(
+            {
+                callback: {
+                    background: true,
+                    url: 'https://example.com',
+                },
+            },
+            options
+        )
         let tx = await req.getTransaction('foo@bar')
         assert.deepStrictEqual(tx, {
             actions: [
@@ -232,7 +283,7 @@ describe('signing request', function() {
         const signatureProvider: SignatureProvider = {
             sign(message) {
                 return mockSig
-            }
+            },
         }
         const req1 = await SigningRequest.create(
             {
@@ -257,25 +308,30 @@ describe('signing request', function() {
     })
 
     it('should encode and decode test requests', async function() {
-        let req1uri = 'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKiMDAA'
-        let req2uri = 'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKkR3TDFQtYKjRZLW-rkn5z86tuzPxn7zSXZ7lkyOdFE_-tTE8_bqS4ab6vnUd_LqHG3ZVHCmNnW9qt6zEx9amy_k_FC6nqX1Uf7TdgA'
+        let req1uri =
+            'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKiMDAA'
+        let req2uri =
+            'eosio:gWNgZGBY1mTC_MoglIGBIVzX5uxZoAgIaMSCyBVvjYx0kAUYGNZZvmCGsJhd_YNBNHdGak5OvkJJRmpRKkR3TDFQtYKjRZLW-rkn5z86tuzPxn7zSXZ7lkyOdFE_-tTE8_bqS4ab6vnUd_LqHG3ZVHCmNnW9qt6zEx9amy_k_FC6nqX1Uf7TdgA'
         let req1 = SigningRequest.from(req1uri, options)
         let req2 = SigningRequest.from(req2uri, options)
         assert.deepStrictEqual(req1.getActions(), req2.getActions())
         assert.strictEqual(req1.signature, undefined)
         assert.deepStrictEqual(req2.signature, {
-            signer: "foobar",
-            signature: "SIG_K1_KdHDFseJF6paedvSbfHFZzhbtBDVAM8LxeDJsrG33sENRbUQMFHX8CvtT9wRLo4fE4QGYtbp1rF6BqNQ6Pv5XgSocXwM67"
+            signer: 'foobar',
+            signature:
+                'SIG_K1_KdHDFseJF6paedvSbfHFZzhbtBDVAM8LxeDJsrG33sENRbUQMFHX8CvtT9wRLo4fE4QGYtbp1rF6BqNQ6Pv5XgSocXwM67',
         })
         assert.strictEqual(req1.encode(), req1uri)
         assert.strictEqual(req2.encode(), req2uri)
-        let req3uri = "eosio:gWNgZGZkgABGBqYI7x9Sxl36f-rbJt9s2lUzbYe3pdtE7WnPfxy7_pAph3k5A6NKTmZetpW-fnKGXmJeckZ-kR5IQN_QyNhE18TUzFzXwtLAgBEA"
+        let req3uri =
+            'eosio:gWNgZGZkgABGBqYI7x9Sxl36f-rbJt9s2lUzbYe3pdtE7WnPfxy7_pAph3k5A6NKTmZetpW-fnKGXmJeckZ-kR5IQN_QyNhE18TUzFzXwtLAgBEA'
         let req3 = SigningRequest.from(req3uri, options)
         assert.strictEqual(req3.isIdentity(), true)
         assert.strictEqual(req3.getIdentity(), null)
-        assert.strictEqual(req3.getIdentityKey(), "PUB_K1_5ZNmwoFDBPVnL2CYgZRpHqFfaK2M9bCFJJ1SapR9X4KPRdJ9eK")
+        assert.strictEqual(
+            req3.getIdentityKey(),
+            'PUB_K1_5ZNmwoFDBPVnL2CYgZRpHqFfaK2M9bCFJJ1SapR9X4KPRdJ9eK'
+        )
         assert.strictEqual(req3.encode(), req3uri)
     })
-
-
 })

--- a/test/utils/mock-abi-provider.ts
+++ b/test/utils/mock-abi-provider.ts
@@ -6,10 +6,10 @@ import {AbiProvider} from '../../src'
 // CONTRACT=eosio.token; cleos -u https://eos.greymass.com get abi $CONTRACT > test/abis/$CONTRACT.json
 
 export class MockAbiProvider implements AbiProvider {
-    constructor(public readonly abis: {[account: string]: any}) {}
+    constructor(public readonly abis: Map<string, any>) {}
 
     public async getAbi(account: string) {
-        const abi = this.abis[account]
+        const abi = this.abis.get(account)
         if (!abi) {
             throw new Error(`No ABI for: ${account}`)
         }
@@ -19,9 +19,9 @@ export class MockAbiProvider implements AbiProvider {
 
 function createTestProvider() {
     const dir = joinPath(__dirname, '../abis')
-    const abis: {[account: string]: any} = {}
+    const abis = new Map<string, any>()
     readdir(dir).forEach((name) => {
-        abis[name.slice(0, -5)] = JSON.parse(readfile(joinPath(dir, name)).toString('utf8'))
+        abis.set(name.slice(0, -5), JSON.parse(readfile(joinPath(dir, name)).toString('utf8')))
     })
     return new MockAbiProvider(abis)
 }

--- a/test/utils/mock-abi-provider.ts
+++ b/test/utils/mock-abi-provider.ts
@@ -6,13 +6,12 @@ import {AbiProvider} from '../../src'
 // CONTRACT=eosio.token; cleos -u https://eos.greymass.com get abi $CONTRACT > test/abis/$CONTRACT.json
 
 export class MockAbiProvider implements AbiProvider {
-
     constructor(public readonly abis: {[account: string]: any}) {}
 
     public async getAbi(account: string) {
         const abi = this.abis[account]
         if (!abi) {
-            throw new Error(`No ABI for: ${ account }`)
+            throw new Error(`No ABI for: ${account}`)
         }
         return abi
     }

--- a/tslint.json
+++ b/tslint.json
@@ -1,14 +1,14 @@
 {
-  "defaultSeverity": "error",
-  "extends": ["tslint:recommended"],
+  "extends": [
+    "tslint-plugin-prettier",
+    "tslint-config-prettier"
+  ],
   "rules": {
-    "indent": [true, "spaces", 4],
-    "interface-name": [true, "never-prefix"],
-    "max-classes-per-file": false,
-    "no-bitwise": false,
-    "object-literal-sort-keys": false,
-    "quotemark": [true, "single", "avoid-escape"],
-    "semicolon": [true, "never"],
-    "triple-equals": [true, "allow-null-check"]
+    "prettier": true,
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "ordered-imports": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+fast-sha256@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.1.1.tgz#2a1fca6a7fd0943da478f17760d19cf52ba78dea"
+  integrity sha512-CKUjAtRhTHaLueE7eUPX4009H7yMZxxBWHYxvzCn3WySKza5+S5EknF86zpOzF4Is4/qNUzbrhtC19gUMzCUdQ==
+
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,6 +359,14 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-plugin-prettier@^2.2.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
+  integrity sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -389,6 +397,11 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+fast-diff@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-sha256@^1.1.1:
   version "1.1.1"
@@ -559,6 +572,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+  integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
+
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -586,6 +604,11 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -823,6 +846,11 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -1028,10 +1056,29 @@ ts-node@^8.2.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+tslib@^1.7.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslint-config-prettier@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
+  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
+
+tslint-plugin-prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz#95b6a3b766622ffc44375825d7760225c50c3680"
+  integrity sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==
+  dependencies:
+    eslint-plugin-prettier "^2.2.0"
+    lines-and-columns "^1.1.6"
+    tslib "^1.7.1"
 
 tslint@^5.12.0:
   version "5.12.0"


### PR DESCRIPTION
Adds an identity (aka login) request type, optional request signatures and request metadata. This also changes the uri scheme to `esr` (previously `eosio`). Bumps protocol version to `2`.

## Updates

### Protocol version

Includes breaking ABI changes, protocol version is increased to `2`.

### ABI

 - `callback` is now always a string, an empty string denotes no callback.
 - `broadcast` field removed and replaced with `flags`
   - uint8 type
   - `1 << 0` = request should be broadcast
   - `1 << 1` =  callback should be sent in background if possible (previously `callback.background: bool`)
 - `info` dict added, with eosio-abigen style map: `[{key: "string", value: "bytes"}, ..]`

### New placeholder

The name `............2` will now resolve to signing permission when used in actions.

### Request signatures

Optional request signatures appended to end of request data.

```
<header><req_data>[req_signature]
```

Signatures are generated as follows:

```
sign(sha256(protocol_version + "request" + req_data))
```

and packed as:

```cpp
struct req_signature {
    eosio::name signer;
    eosio::signature signature;
}
```

### Identity requests

Adds a new variant type `identity` to request data with the following structure:

```cpp
struct identity {
    std::optional<eosio::permission_level> permission;
}
```

The permission level can use placeholders indicate what permission the request is valid for, examples: 

```
............1@............2 // any account and permission level
............1@foo // any account with the permission level "foo"
foo@............2 // the account "foo" with any permission level
```

Setting the optional permission to null is equivalent to `............1@............2` since this is the most common request.

### Callback context additions

- `sq` - signing account actor (aka account name), e.g. `myaccount`
- `sp` - signing account permission, e.g. `active`
- `ex` - resolved transaction expiry time, e.g. `1970-01-01T00:00:00`
- `rbn`- reference block num used when resolving reques
- `rid` - reference block id used when resolving the request
- `req` - the originating signing request packed as a uri string

These additions allows a callback receiver to reconstruct the resolved transaction the sender signed.
